### PR TITLE
Add missing "else" in FixOrder() function

### DIFF
--- a/Server/ServerFunctionality/CalculationEngine.cs
+++ b/Server/ServerFunctionality/CalculationEngine.cs
@@ -24,7 +24,7 @@ namespace ServerFunctionality
                     operations.Remove('^');
                     i--;
                 }
-                if (operations.ElementAt(i) == '*')
+                else if (operations.ElementAt(i) == '*')
                 {
                     numbers[i] = MulNumbers(numbers.ElementAt(i), numbers.ElementAt(i + 1));
                     numbers.RemoveAt(i + 1);


### PR DESCRIPTION
There was missing `else` statement that was causing parser to fail due to `OutOfRange` exception.