### PR TITLE
Fix trigonometrical functions for very low numbers

### DIFF
--- a/Server/ServerFunctionality/Parser.cs
+++ b/Server/ServerFunctionality/Parser.cs
@@ -116,6 +116,7 @@ namespace ServerFunctionality
                 case "ctg": result = Math.Atan2(1, ptrig.getResult() * Math.PI / 180); break;
                 default: throw new FormatException("Wrong operation.");
             }
+            if (result < 0.00000000001) result = 0;
             userInput = userInput.Insert(startIndex - 4, result.ToString());
         }
 


### PR DESCRIPTION
Trigonometrical functions were returning results in `E notation` due to low `Math.PI` precision. It was causing parser to fail. To fix that very low numbers in `E notation` are changed to `0`.